### PR TITLE
Skip windows/arm release builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,6 +20,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: arm
+      - goos: windows
+        goarch: arm
     main: ./cmd/goshot
     ldflags:
       - -s -w


### PR DESCRIPTION
Go dropped the 32-bit windows/arm port; the v0.8.0 release run failed on it. This skips the pair like darwin/arm.